### PR TITLE
Fix issue with soothing hot chocolate quest and slumbering lichbane p…

### DIFF
--- a/config/ftbquests/quests/chapters/the_black_market.snbt
+++ b/config/ftbquests/quests/chapters/the_black_market.snbt
@@ -1395,7 +1395,7 @@
 					consume_items: true
 					count: 2000L
 					id: "584300D656F07686"
-					item: "iceandfire:silver_ingot"
+					item: "samurai_dynasty:silver_ingot"
 					type: "item"
 				}
 				{
@@ -3407,6 +3407,7 @@
 			shape: "gear"
 			size: 1.5d
 			tasks: [{
+				consume_items: true
 				count: 10000L
 				id: "623158969F101E54"
 				item: "create_confectionery:soothing_hot_chocolate"


### PR DESCRIPTION
…urchase

Adding "consume items" to soothing hot chocolate challenge allows item turnins.  I could not find any other way to get quest credit for more hot chocolates than can hold in personal inventory at a single time.

Slumbering lichbane purchase was asking for Ice and Fire silver ingot when due to consolidation changes we can only make Samurai Dynasty silver ingots.  Quick fix.